### PR TITLE
Fix missing key attribute in navbar dropdown

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -13,7 +13,7 @@ class NavBar extends React.Component {
     data.map((menuItem) => {
       if (menuItem.node.parentPage === null) {
         return (
-          <Dropdown item text={menuItem.node.title} direction="left">
+          <Dropdown item text={menuItem.node.title} direction="left" key={menuItem.node.title}>
             <Dropdown.Menu>
             { this.renderMenuSubItems(data.filter(subMenuItem =>
               subMenuItem.node.parentPage !== null &&


### PR DESCRIPTION
I noticed this error in the chrome console. I hope i fixed it the right way.