### PR TITLE
Feature/external links

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -3,7 +3,7 @@ import { graphql, StaticQuery, Link } from 'gatsby'
 import styled from 'styled-components'
 import { Dropdown, Image, Menu, Container, Button, Grid } from 'semantic-ui-react'
 import logo from '../images/logo-sticky-small.png'
-import data from '../data/menu.json'
+import menu from '../data/menu.json'
 
 class NavBar extends React.Component {
   renderMenuItems = data =>
@@ -24,6 +24,7 @@ class NavBar extends React.Component {
                     subMenuItem.node.parentPage.slug === menuItem.node.slug
                 )
               )}
+              {this.renderExternMenuItems(menu[menuItem.node.slug])}
             </Dropdown.Menu>
           </Dropdown>
         )
@@ -45,9 +46,8 @@ class NavBar extends React.Component {
       </Dropdown.Item>
     ))
 
-  renderexternMenuItems = externMenuItems =>
-    externMenuItems.map(externMenuItem => {
-      return (
+  renderExternMenuItems = externMenuItems => 
+    externMenuItems.map(externMenuItem => (
         <Dropdown.Item
           className="item"
           key={externMenuItem.title}
@@ -66,7 +66,8 @@ class NavBar extends React.Component {
           </Grid>
         </Dropdown.Item>
       )
-    })
+    )
+
 
   render() {
     return (
@@ -85,7 +86,7 @@ class NavBar extends React.Component {
                 key="extern"
             >
               <Dropdown.Menu>
-                {this.renderexternMenuItems(data.extern)}
+                {this.renderExternMenuItems(menu.extern)}
               </Dropdown.Menu>
             </Dropdown>
             <Menu.Item className="link-item">

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { graphql, StaticQuery, Link } from 'gatsby'
 import styled from 'styled-components'
-import { Dropdown, Image, Menu, Container, Button } from 'semantic-ui-react'
+import { Dropdown, Image, Menu, Container, Button, Grid } from 'semantic-ui-react'
 import logo from '../images/logo-sticky-small.png'
+import data from '../data/menu.json'
 
 class NavBar extends React.Component {
   renderMenuItems = data =>
@@ -44,6 +45,29 @@ class NavBar extends React.Component {
       </Dropdown.Item>
     ))
 
+  renderexternMenuItems = externMenuItems =>
+    externMenuItems.map(externMenuItem => {
+      return (
+        <Dropdown.Item
+          className="item"
+          key={externMenuItem.title}
+          href={externMenuItem.url}
+          target="_blank"
+        >
+          <Grid>
+            <Grid.Row>
+              <Grid.Column width={12}>
+                <p class="item-text icon-item-text">{externMenuItem.title} &emsp;&emsp;</p>
+              </Grid.Column>
+              <Grid.Column>
+                <i class="item-text icon external" />
+              </Grid.Column>
+            </Grid.Row>
+          </Grid>
+        </Dropdown.Item>
+      )
+    })
+
   render() {
     return (
       <NavBarWrapper>
@@ -54,6 +78,16 @@ class NavBar extends React.Component {
             </Image>
             <div style={{ flex: 1 }} />
             {this.renderMenuItems(this.props.data.allContentfulPage.edges)}
+            <Dropdown
+              item
+                text="Extern"
+                direction="left"
+                key="extern"
+            >
+              <Dropdown.Menu>
+                {this.renderexternMenuItems(data.extern)}
+              </Dropdown.Menu>
+            </Dropdown>
             <Menu.Item className="link-item">
               <Button
                 href="http://koala.svsticky.nl"
@@ -88,6 +122,9 @@ const NavBarWrapper = styled.div`
       }
       .item-text {
         color: #000078;
+      }
+      .icon-item-text {
+        padding-right: 5pt;
       }
     }
     .link-item {

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -57,7 +57,7 @@ class NavBar extends React.Component {
           <Grid>
             <Grid.Row>
               <Grid.Column width={12}>
-                <p class="item-text icon-item-text">{externMenuItem.title} &emsp;&emsp;</p>
+                <p class="item-text icon-item-text">{externMenuItem.title}</p>
               </Grid.Column>
               <Grid.Column>
                 <i class="item-text icon external" />
@@ -124,7 +124,7 @@ const NavBarWrapper = styled.div`
         color: #000078;
       }
       .icon-item-text {
-        padding-right: 5pt;
+        padding-right: 20pt;
       }
     }
     .link-item {

--- a/src/data/menu.json
+++ b/src/data/menu.json
@@ -4,7 +4,6 @@
     ],
     "vereniging": [],
     "carriere": [],
-    "disputen": [],
     "extern": [
         {"title":"ODC Informatica", "url":"http://www.cs.uu.nl/docs/committees/odc/"},
         {"title":"SODI", "url": "https://sodi.nl/"}

--- a/src/data/menu.json
+++ b/src/data/menu.json
@@ -4,6 +4,7 @@
     ],
     "vereniging": [],
     "carriere": [],
+    "disputen": [],
     "extern": [
         {"title":"ODC Informatica", "url":"http://www.cs.uu.nl/docs/committees/odc/"},
         {"title":"SODI", "url": "https://sodi.nl/"}

--- a/src/data/menu.json
+++ b/src/data/menu.json
@@ -1,0 +1,7 @@
+{
+    "extern": [
+        {"title":"Boekverkoop", "url":"https://sticky.itdepartment.nl"},
+        {"title":"ODC Informatica", "url":"http://www.cs.uu.nl/docs/committees/odc/"},
+        {"title":"SODI", "url": "https://sodi.nl/"}
+    ]
+}

--- a/src/data/menu.json
+++ b/src/data/menu.json
@@ -1,7 +1,11 @@
 {
+    "studie": [
+        {"title":"Boekverkoop", "url":"https://sticky.itdepartment.nl"}
+    ],
+    "vereniging": [],
+    "carriere": [],
     "extern": [
-        {"title":"Boekverkoop", "url":"https://sticky.itdepartment.nl"},
         {"title":"ODC Informatica", "url":"http://www.cs.uu.nl/docs/committees/odc/"},
         {"title":"SODI", "url": "https://sodi.nl/"}
-    ]
+    ]  
 }


### PR DESCRIPTION
Fixes #32 

Adds an 'Extern' dropdown menu to the navbar. Dropdown items are generated from a new file (src/data/menu.json), with an icon to show they open in an external site (in a new tab).
Grid is used inside the dropdown icons to align the icons on the right side.