### PR TITLE
React Context API

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import ContextProvider from '$/data/Context';
+
+export const wrapRootElement = ({ element }) => {
+  return <ContextProvider>{element}</ContextProvider>;
+};

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import ContextProvider from '$/data/Context';
+
+export const wrapRootElement = ({ element }) => {
+  return <ContextProvider>{element}</ContextProvider>;
+};

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,5 +1,6 @@
 import '$/semantic/dist/semantic.min.css';
 import React from 'react';
+import Context from '$/data/Context';
 import styled from 'styled-components';
 import NavBar from './Navbar';
 import MobileNavbar from './MobileNavbar';
@@ -8,14 +9,14 @@ import { Container } from 'semantic-ui-react';
 import { device } from '../../data/Devices';
 
 const layout = ({ children }) => (
-  <>
+  <Context>
     <NavBar />
     <PageWrapper>
       <StyledContainer className="content">{children}</StyledContainer>
       <Footer />
     </PageWrapper>
     <MobileNavbar />
-  </>
+  </Context>
 );
 
 const StyledContainer = styled(Container)`

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,6 +1,5 @@
 import '$/semantic/dist/semantic.min.css';
 import React from 'react';
-import Context from '$/data/Context';
 import styled from 'styled-components';
 import NavBar from './Navbar';
 import MobileNavbar from './MobileNavbar';
@@ -9,14 +8,14 @@ import { Container } from 'semantic-ui-react';
 import { device } from '../../data/Devices';
 
 const layout = ({ children }) => (
-  <Context>
+  <>
     <NavBar />
     <PageWrapper>
       <StyledContainer className="content">{children}</StyledContainer>
       <Footer />
     </PageWrapper>
     <MobileNavbar />
-  </Context>
+  </>
 );
 
 const StyledContainer = styled(Container)`

--- a/src/data/Context.jsx
+++ b/src/data/Context.jsx
@@ -1,16 +1,30 @@
 import React, { Component } from 'react';
 
-const globalState = React.createContext();
+export const globalState = React.createContext();
 
 class globalStateProvider extends Component {
   state = {
     lastReadNewsPage: 0,
   };
+
+  actions = {
+    updateLastReadNewsPage: page => {
+      this.setState({ lastReadNewsPage: page });
+    },
+  };
+
   render() {
     return (
-      <globalState.Provider value={this.state}>
+      <globalState.Provider
+        value={{
+          state: this.state,
+          actions: this.actions,
+        }}
+      >
         {this.props.children}
       </globalState.Provider>
     );
   }
 }
+
+export default globalStateProvider;

--- a/src/data/Context.jsx
+++ b/src/data/Context.jsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 
-export const globalState = React.createContext();
+export const GlobalState = React.createContext();
 
-class globalStateProvider extends Component {
+class GlobalStateProvider extends Component {
   state = {
     lastReadNewsPage: 0,
   };
@@ -15,16 +15,16 @@ class globalStateProvider extends Component {
 
   render() {
     return (
-      <globalState.Provider
+      <GlobalState.Provider
         value={{
           state: this.state,
           actions: this.actions,
         }}
       >
         {this.props.children}
-      </globalState.Provider>
+      </GlobalState.Provider>
     );
   }
 }
 
-export default globalStateProvider;
+export default GlobalStateProvider;

--- a/src/data/Context.jsx
+++ b/src/data/Context.jsx
@@ -1,0 +1,16 @@
+import React, { Component } from 'react';
+
+const globalState = React.createContext();
+
+class globalStateProvider extends Component {
+  state = {
+    lastReadNewsPage: 0,
+  };
+  render() {
+    return (
+      <globalState.Provider value={this.state}>
+        {this.props.children}
+      </globalState.Provider>
+    );
+  }
+}


### PR DESCRIPTION
Implements the React Context API to keep track of global state throughout the website. First usage for now is the News on the index page. A little question that arises for now: 
If a user clicks on page 3, whatever the user does following that, and then returns to the index again, the news will still paginate on page 3. This stays this way, and is only 'resetted' on a close and open of the complete website. Is this what we want?