### PR TITLE
Fix overflowing news items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "static-sticky",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/News.jsx
+++ b/src/components/News.jsx
@@ -33,6 +33,11 @@ class News extends React.Component {
         )
         .map(item => {
           let cutarr = [' ', ',', '.', '\n'];
+          item.node.content.content = item.node.content.content.replaceAll(
+            /\[([^[\]]*)\]\((.*?)\)/gm,
+            '$1'
+          );
+          console.log(item.node.content.content);
           if (item.node.content.content.length > 400) {
             for (let i = 400; i < item.node.content.content.length; i++) {
               if (cutarr.indexOf(item.node.content.content[i]) > -1) {

--- a/src/components/News.jsx
+++ b/src/components/News.jsx
@@ -33,11 +33,11 @@ class News extends React.Component {
         )
         .map(item => {
           let cutarr = [' ', ',', '.', '\n'];
-          item.node.content.content = item.node.content.content.replaceAll(
+          //Removes link and figure content
+          item.node.content.content = item.node.content.content.replace(
             /\[([^[\]]*)\]\((.*?)\)/gm,
             '$1'
           );
-          console.log(item.node.content.content);
           if (item.node.content.content.length > 400) {
             for (let i = 400; i < item.node.content.content.length; i++) {
               if (cutarr.indexOf(item.node.content.content[i]) > -1) {


### PR DESCRIPTION
Remove url and image tags from the news previews to prevent the news list container on the home page from overflowing.