### PR TITLE
pass workflow to failing ci task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
         uses: n1hility/cancel-previous-runs@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name }} != 'schedule'
       - uses: actions/cache@v2.1.6
         with:
           path: node_modules


### PR DESCRIPTION
This should hopefully fix #314 by ignoring the `cancel-previous-runs` task on a scheduled run.
This task will otherwise fail because of a missing `workflow` setting (see https://github.com/n1hility/cancel-previous-runs).

Github actions scheduled dispatch is not really testable, because '"Scheduled workflows run on the latest commit on the default or base branch" (https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#scheduled-events)
Github also doesn't describe in the docs what the values of the `github.event_name` environment variable are (or when it is set, or anything really), but in the code of  `cancel-previous-runs` I discovered the value I now check for.