### PR TITLE
Disable using google fonts

### DIFF
--- a/src/semantic/src/themes/default/globals/site.variables
+++ b/src/semantic/src/themes/default/globals/site.variables
@@ -14,7 +14,7 @@
 @pageFont          : @fontName, 'Helvetica Neue', Arial, Helvetica, sans-serif;
 
 @googleFontName    : @fontName;
-@importGoogleFonts : true;
+@importGoogleFonts : false;
 @googleFontSizes   : 'ital,wght@0,400%3B0,700%3B1,400%3B1,700';
 @googleSubset      : 'latin';
 @googleFontDisplay : 'swap';


### PR DESCRIPTION
This disables importing google fonts on the website, and does seem to change nothing in the styling.
This is in light of the recent ruling of a German court that including Google Fonts is against the GDPR.
See https://www.theregister.com/2022/01/31/website_fine_google_fonts_gdpr/
Although this might not hold for Dutch law, let's err on the safe side (especially since it is so easy).