### PR TITLE
Remove `mailto:` and `tel:` from contact cards

### DIFF
--- a/src/components/ContactPerson.jsx
+++ b/src/components/ContactPerson.jsx
@@ -32,20 +32,8 @@ const ContactPerson = ({ contactPerson }) => (
                 {contactPerson.name +
                   (contactPerson.role ? ' (' + contactPerson.role + ')' : '')}
               </p>
-              <p>
-                Tel.:
-                <a href={'tel:' + contactPerson.mobile}>
-                  {' '}
-                  {contactPerson.mobile}
-                </a>
-              </p>
-              <p>
-                Mail:
-                <a href={'mailto:' + contactPerson.email}>
-                  {' '}
-                  {contactPerson.email}
-                </a>
-              </p>
+              <p>Tel.: {contactPerson.mobile}</p>
+              <p>Mail: {contactPerson.email}</p>
             </div>
           </div>
         </Card.Content>
@@ -53,6 +41,14 @@ const ContactPerson = ({ contactPerson }) => (
     </div>
   </ContactPersonMember>
 );
+
+function getEmailDomain(email) {
+  return email.split('@')[1];
+}
+
+function getEmailName(email) {
+  return email.split('@')[0];
+}
 
 const ContactPersonMember = styled.div`
   .head {


### PR DESCRIPTION
Closes #319 

# Changes
- Remove `mailto:` and `tel:` from the contact person card
- Remove the now unnecessary `<a>` link.

# Reasoning
>The email addresses from the website are being scraped. This is not a huge problem for the board, who use a good spam filter, but it is for the confidential counselors, who are just members that use their personal email.
Instead of displaying the email addresses with the mailto: property, we should display them as plain text, and split up the addresses in separate parts so crawling becomes harder.

- Decreasing spam for confidential advisors and the board due to web scraping
- I did not split the text, this looked terrible (UI).

# Downsize
- You can now no longer click the link to send an email, you need to copy the address instead, in my opinion that is fine.