### PR TITLE
fix: image size based on parent

### DIFF
--- a/src/semantic/src/themes/default/globals/reset.overrides
+++ b/src/semantic/src/themes/default/globals/reset.overrides
@@ -147,6 +147,8 @@ sup {
 
 img {
   border-style: none;
+    max-width: 100%;
+    height: auto;
 }
 
 /* Forms


### PR DESCRIPTION
Currently, when fetching an image from Contentfull, the image size is proportional to image size. 

After this PR; default image witdth should be based on the size of the parent element