### PR TITLE
Bump markdown-to-jsx from 7.1.5 to 7.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "gatsby-plugin-react-intl": "^3.0.2",
         "gatsby-plugin-styled-components": "^4.14.0",
         "gatsby-source-contentful": "^5.14.1",
-        "markdown-to-jsx": "^7.1.5",
+        "markdown-to-jsx": "^7.4.0",
         "react": "^16.14.0",
         "react-currency-formatter": "^1.1.0",
         "react-dom": "^16.14.0",
@@ -19596,9 +19596,10 @@
       }
     },
     "node_modules/markdown-to-jsx": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.5.tgz",
-      "integrity": "sha512-YQEMMMCX3PYOWtUAQu8Fmz5/sH09s17eyQnDubwaAo8sWmnRTT1og96EFv1vL59l4nWfmtF3L91pqkuheVqRlA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.4.0.tgz",
+      "integrity": "sha512-zilc+MIkVVXPyTb4iIUTIz9yyqfcWjszGXnwF9K/aiBWcHXFcmdEMTkG01/oQhwSCH7SY1BnG6+ev5BzWmbPrg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       },
@@ -43706,9 +43707,9 @@
       }
     },
     "markdown-to-jsx": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.5.tgz",
-      "integrity": "sha512-YQEMMMCX3PYOWtUAQu8Fmz5/sH09s17eyQnDubwaAo8sWmnRTT1og96EFv1vL59l4nWfmtF3L91pqkuheVqRlA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.4.0.tgz",
+      "integrity": "sha512-zilc+MIkVVXPyTb4iIUTIz9yyqfcWjszGXnwF9K/aiBWcHXFcmdEMTkG01/oQhwSCH7SY1BnG6+ev5BzWmbPrg==",
       "requires": {}
     },
     "matchdep": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gatsby-plugin-react-intl": "^3.0.2",
     "gatsby-plugin-styled-components": "^4.14.0",
     "gatsby-source-contentful": "^5.14.1",
-    "markdown-to-jsx": "^7.1.5",
+    "markdown-to-jsx": "^7.4.0",
     "react": "^16.14.0",
     "react-currency-formatter": "^1.1.0",
     "react-dom": "^16.14.0",


### PR DESCRIPTION
# This breaks the markdown at the `/nl/studie/oer` page, but does fix high level security exploit

Bumps [markdown-to-jsx](https://github.com/quantizor/markdown-to-jsx) from 7.1.5 to 7.4.0.
- [Release notes](https://github.com/quantizor/markdown-to-jsx/releases)
- [Changelog](https://github.com/quantizor/markdown-to-jsx/blob/main/CHANGELOG.md)
- [Commits](https://github.com/quantizor/markdown-to-jsx/compare/7.1.5...v7.4.0)

---
updated-dependencies:
- dependency-name: markdown-to-jsx dependency-type: direct:production ...